### PR TITLE
Only show the notice on the options-general.php page

### DIFF
--- a/wps-hide-login.php
+++ b/wps-hide-login.php
@@ -322,7 +322,8 @@ if ( defined( 'ABSPATH' )
 
 			if ( ! is_network_admin()
 				&& $pagenow === 'options-general.php'
-				&& isset( $_GET['settings-updated'] ) ) {
+				&& isset( $_GET['settings-updated'] )
+				&& ! isset( $_GET['page'] ) ) {
 
 				echo '<div class="updated notice is-dismissible"><p>' . sprintf( __( 'Your login page is now here: <strong><a href="%1$s">%2$s</a></strong>. Bookmark this page!', 'wps-hide-login' ), $this->new_login_url(), $this->new_login_url() ) . '</p></div>';
 


### PR DESCRIPTION
Hi,

I fix the plugin to show the notice only on the right page.
It's disturbing to have it when saving other plugin settings ;)