### PR TITLE
Add a filter similar to WP's login_redirect for handling logged in re...

### DIFF
--- a/classes/plugin.php
+++ b/classes/plugin.php
@@ -448,9 +448,30 @@ class Plugin {
 		} elseif ( $pagenow === 'wp-login.php' ) {
 			global $error, $interim_login, $action, $user_login;
 
-			if ( is_user_logged_in() && ! isset( $_REQUEST['action'] ) ) {
-				wp_safe_redirect( admin_url() );
-				die();
+			$redirect_to = admin_url();
+			
+			if ( isset( $_REQUEST['redirect_to'] ) ) {
+				$requested_redirect_to = $_REQUEST['redirect_to'];
+			}
+
+			if ( is_user_logged_in() ) {
+				$user = wp_get_current_user();
+
+				if (
+					( ! isset( $_REQUEST['action'] ) &&
+						isset( $requested_redirect_to )
+					) || (
+						! isset( $_REQUEST['action'] )
+					) ) {
+
+					$logged_in_redirect = apply_filters('whl_logged_in_redirect', $redirect_to, $requested_redirect_to, $user);
+
+					wp_safe_redirect( $logged_in_redirect );
+
+					die();
+
+				}
+
 			}
 
 			@require_once ABSPATH . 'wp-login.php';


### PR DESCRIPTION
...directs.

WordPress's `login_redirect` filter ([see here](https://developer.wordpress.org/reference/hooks/login_redirect/)) allows us to handle how a user who is already logged in gets redirected ([see here](https://wordpress.stackexchange.com/questions/270379/wp-login-php-redirect-logged-in-users-to-custom-url)).

With WPS Hide Login, a user who is already logged in and opens a URL with the `redirect_to` query parameters is __always__ sent to the admin dashboard. The query parameter is ignored.

This PR adds a new filter `whl_logged_in_redirect` which works similar to the `login_redirect` provided by WordPress - except for WPS Hide Login, it is specifically targeted to redirect in cases where the user is already logged in.